### PR TITLE
Use clojure.future/double?

### DIFF
--- a/src/clojure/spec.clj
+++ b/src/clojure/spec.clj
@@ -1827,7 +1827,7 @@
   [& {:keys [infinite? NaN? min max]
     :or {infinite? true NaN? true}
     :as m}]
-  `(spec (and c/double?
+  `(spec (and double?
               ~@(when-not infinite? '[#(not (Double/isInfinite %))])
               ~@(when-not NaN? '[#(not (Double/isNaN %))])
               ~@(when max `[#(<= % ~max)])


### PR DESCRIPTION
`double-in` spec depends on `clojure.core/double?` which was introduced in 1.9. It should use `clojure.future/double?` instead.
