### PR TITLE
1.9.0-alpha16

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this to your project.clj:
 ```clj
 :dependencies [
   [org.clojure/clojure "1.8.0"]
-  [clojure-future-spec "1.9.0-alpha15"]
+  [clojure-future-spec "1.9.0-alpha16"]
   [org.clojure/test.check "0.9.0"] ;; only if you need generators
 ]
 ```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-future-spec "1.9.0-alpha15"
+(defproject clojure-future-spec "1.9.0-alpha16"
   :description "Backport of clojure.spec for Clojure 1.8"
   :url "https://github.com/tonsky/clojure-future-spec"
   :license {:name "Eclipse Public License"

--- a/src/clojure/core/specs/alpha.clj
+++ b/src/clojure/core/specs/alpha.clj
@@ -1,7 +1,6 @@
-(ns ^{:skip-wiki true} clojure.core.specs
-  (:require
-    [clojure.spec :as s]
-    [clojure.future :refer :all]))
+(ns ^{:skip-wiki true} clojure.core.specs.alpha
+  (:require [clojure.spec.alpha :as s]
+            [clojure.future :refer :all]))
 
 ;;;; destructure
 

--- a/src/clojure/spec/gen/alpha.clj
+++ b/src/clojure/spec/gen/alpha.clj
@@ -6,11 +6,10 @@
 ;   the terms of this license.
 ;   You must not remove this notice, or any other, from this software.
 
-(ns clojure.spec.gen
+(ns clojure.spec.gen.alpha
     (:refer-clojure :exclude [boolean bytes cat hash-map list map not-empty set vector
                               char double int keyword symbol string uuid delay])
-  (:require
-    [clojure.future :refer :all]))
+    (:require [clojure.future :refer :all]))
 
 (alias 'c 'clojure.core)
 
@@ -194,8 +193,8 @@ gens, each of which should generate something sequential."
     (get @gen-builtins pred)))
 
 (comment
-  (require :reload 'clojure.spec.gen)
-  (in-ns 'clojure.spec.gen)
+  (require :reload 'clojure.spec.gen.alpha)
+  (in-ns 'clojure.spec.gen.alpha)
 
   ;; combinators, see call to lazy-combinators above for complete list
   (generate (one-of [(gen-for-pred integer?) (gen-for-pred string?)]))
@@ -222,3 +221,4 @@ gens, each of which should generate something sequential."
   (gen-for-name 'ns.does.not.exist/f)
   
   )
+

--- a/src/clojure/spec/test/alpha.clj
+++ b/src/clojure/spec/test/alpha.clj
@@ -6,17 +6,17 @@
 ;   the terms of this license.
 ;   You must not remove this notice, or any other, from this software.
 
-(ns clojure.spec.test
+(ns clojure.spec.test.alpha
   (:refer-clojure :exclude [test])
   (:require
    [clojure.pprint :as pp]
-   [clojure.spec :as s]
-   [clojure.spec.gen :as gen]
+   [clojure.spec.alpha :as s]
+   [clojure.spec.gen.alpha :as gen]
    [clojure.string :as str]
    [clojure.future :refer :all]))
 
 (in-ns 'clojure.spec.test.check)
-(in-ns 'clojure.spec.test)
+(in-ns 'clojure.spec.test.alpha)
 (alias 'stc 'clojure.spec.test.check)
 
 (defn- throwable?
@@ -108,7 +108,7 @@ interpret-stack-trace-element that are relevant to a
 failure in instrument."
   [elems]
   (let [plumbing? (fn [{:keys [var-scope]}]
-                    (contains? '#{clojure.spec.test/spec-checking-fn} var-scope))]
+                    (contains? '#{clojure.spec.test.alpha/spec-checking-fn} var-scope))]
     (sequence (comp (map StackTraceElement->vec)
                     (map interpret-stack-trace-element)
                     (filter :var-scope)
@@ -462,6 +462,5 @@ key with a count for each different :type of result."
             (update (result-type result) (fnil inc 0))))
       {:total 0}
        check-results)))
-
 
 


### PR DESCRIPTION
This updates namespaces to reflect the [clojure.spec.alpha split](https://github.com/clojure/spec.alpha/commit/2824ad49df8deadcb4b75acdf624e732a85b4ac7).